### PR TITLE
Implement TM conversion to String

### DIFF
--- a/src/GrammarReader.hs
+++ b/src/GrammarReader.hs
@@ -27,8 +27,6 @@ import CFG2TM
 import ParsingHelpers
 import TuringMachineWriter
 
-import TMType
-
 -- |Parser part.
 
 -- |Parsers for terminal symbols in given grammar: it might be Epsilon, Nonterminal, Terminal, Conjunction or Negation
@@ -168,6 +166,7 @@ checkGrammarType' symbols
     | (List.elem (O Conjunction) symbols) && not (List.elem (O Negation) symbols) = Conjunctive
     | not (List.elem (O Conjunction) symbols) && not (List.elem (O Negation) symbols) = CFG
 
+parser :: Parser Grammar
 parser = makeEofParser pGrammar
 
 --temporary added deriving show to all types in GrammarType module

--- a/src/GrammarReader.hs
+++ b/src/GrammarReader.hs
@@ -25,6 +25,7 @@ import qualified System.Environment as SE
 import GrammarType
 import CFG2TM
 import ParsingHelpers
+import TuringMachineWriter
 
 -- |Parser part.
 
@@ -176,7 +177,7 @@ convertGrammar2TM grammarFile errorFile = do
       Right cs -> case (checkGrammarType cs) of
           Boolean -> putStrLn ("Boolean " ++ show cs) -- here will be new algorithm
           Conjunctive -> putStrLn ("Conjunctive " ++ show cs)
-          CFG -> putStrLn ("CFG " ++ show cs ++ "\n" ++ show (cfg2tm cs))
+          CFG -> putStrLn ("CFG " ++ show cs ++ "\n" ++ toTMSimulator (cfg2tm cs))
 
 
 -- |Valid examples of input

--- a/src/GrammarReader.hs
+++ b/src/GrammarReader.hs
@@ -27,6 +27,8 @@ import CFG2TM
 import ParsingHelpers
 import TuringMachineWriter
 
+import TMType
+
 -- |Parser part.
 
 -- |Parsers for terminal symbols in given grammar: it might be Epsilon, Nonterminal, Terminal, Conjunction or Negation
@@ -177,7 +179,9 @@ convertGrammar2TM grammarFile errorFile = do
       Right cs -> case (checkGrammarType cs) of
           Boolean -> putStrLn ("Boolean " ++ show cs) -- here will be new algorithm
           Conjunctive -> putStrLn ("Conjunctive " ++ show cs)
-          CFG -> putStrLn ("CFG " ++ show cs ++ "\n" ++ showAsTms (cfg2tm cs))
+          CFG -> putStrLn ("CFG " ++ show cs) >> case tm2tms (cfg2tm cs) of
+            Left err -> hPutStrLn stderr $ "Error: " ++ show err
+            Right tms -> putStrLn ("\n" ++ show tms)
 
 
 -- |Valid examples of input

--- a/src/GrammarReader.hs
+++ b/src/GrammarReader.hs
@@ -24,10 +24,9 @@ import qualified System.Environment as SE
 
 import GrammarType
 import CFG2TM
+import ParsingHelpers
 
 -- |Parser part.
-type Parser = Parsec Void Text
-
 
 -- |Parsers for terminal symbols in given grammar: it might be Epsilon, Nonterminal, Terminal, Conjunction or Negation
 pEpsilon :: Parser Symbol
@@ -166,9 +165,7 @@ checkGrammarType' symbols
     | (List.elem (O Conjunction) symbols) && not (List.elem (O Negation) symbols) = Conjunctive
     | not (List.elem (O Conjunction) symbols) && not (List.elem (O Negation) symbols) = CFG
 
-parser = (pGrammar <* eof)
-
-parseFromFile p errorFileName grammarFileName = runParser p errorFileName <$> ((fromString) <$> readFile grammarFileName)
+parser = makeEofParser pGrammar
 
 --temporary added deriving show to all types in GrammarType module
 convertGrammar2TM :: String -> String -> IO ()

--- a/src/ParsingHelpers.hs
+++ b/src/ParsingHelpers.hs
@@ -1,0 +1,15 @@
+module ParsingHelpers (Parser, makeEofParser, parseFromFile) where
+
+import Text.Megaparsec
+
+import Data.Text (Text)
+import Data.String
+import Data.Void
+
+type Parser = Parsec Void Text
+
+makeEofParser :: Parser a -> Parser a
+makeEofParser p = p <* eof
+
+parseFromFile :: Parser a -> String -> String -> IO (Either (ParseErrorBundle Text Void) a)
+parseFromFile p errorFileName grammarFileName = runParser p errorFileName <$> ((fromString) <$> readFile grammarFileName)

--- a/src/TmsType.hs
+++ b/src/TmsType.hs
@@ -1,0 +1,83 @@
+-- |This module provides types for representing turing machines in a format suitable for the service: https://turingmachinesimulator.com/
+-- Below this format will be called Tms.
+
+module TmsType where
+
+import Data.List (intercalate)
+import Data.List.Utils (replace)
+import GHC.Unicode (isAlphaNum)
+
+import TMType
+
+-- |Type of Tms tape square action.
+--
+-- 'Leave' is leave any character unchanged.
+--
+-- 'ChangeFromTo f t' is change it from 'f' to 't'.
+--
+-- 'ChangeTo t' is change it from anything to 't'.
+data TmsTapeSquare = Leave | ChangeFromTo Char Char | ChangeTo Char
+
+-- |Type of Tms tape head movement
+data TmsTapeHeadMovement = MoveLeft | Stay | MoveRight
+
+instance Show TmsTapeHeadMovement where
+    show MoveLeft  = "<"
+    show Stay      = "-"
+    show MoveRight = ">"
+
+-- |Type of Tms command for one tape.
+-- TmsSingleTapeCommand (action, prevState, nextState, movement).
+newtype TmsSingleTapeCommand = TmsSingleTapeCommand (TmsTapeSquare, State, State, TmsTapeHeadMovement)
+
+-- |Type of Tms command for entire Turing machine.
+newtype TmsCommand = TmsCommand [TmsSingleTapeCommand]
+
+-- |Type of Tms format.
+-- Tms (name, initState, acceptStates, commands, tapeAlphabets).
+newtype Tms = Tms (String, [State], [[State]], [TmsCommand], [[Char]])
+
+instance Show Tms where
+    show
+        (Tms
+            (name,
+            initial,
+            acStates,
+            commands,
+            tapeAlphabets)
+        ) = "name: " ++ name ++ "\n" ++
+        "init: " ++ mergeMultipleTapeStates initial ++ "\n" ++
+        "accept: " ++ intercalate ", " (map mergeMultipleTapeStates acStates) ++ "\n\n" ++
+        intercalate "\n\n" (map showTmsCommand commands)
+        where
+            showTmsCommand :: TmsCommand -> String
+            showTmsCommand (TmsCommand tapeCommands) = intercalate "\n" $ map showSingleCmd $ combine $ map extCommand (zip tapeAlphabets tapeCommands)
+            extCommand :: ([Char], TmsSingleTapeCommand) -> [((State, Char), (State, Char, TmsTapeHeadMovement))]
+            extCommand (alph, (TmsSingleTapeCommand (Leave, iniSt, folSt, mv))) =
+                [((iniSt, ch), (folSt, ch, mv)) | ch <- '_' : alph]
+            extCommand (_,    (TmsSingleTapeCommand (ChangeFromTo cF cT, iniSt, folSt, mv))) =
+                [((iniSt, cF), (folSt, cT, mv))]
+            extCommand (alph, (TmsSingleTapeCommand (ChangeTo cT, iniSt, folSt, mv))) =
+                [((iniSt, cF), (folSt, cT, mv)) | cF <- '_' : alph]
+            combine = map Prelude.reverse . foldl (\combs cur -> flip (:) <$> combs <*> cur) [[]]
+            showSingleCmd :: [((State, Char), (State, Char, TmsTapeHeadMovement))] -> String
+            showSingleCmd cmds = intercalate ", " (iniStateName : iniSquares) ++ "\n" ++
+                                 intercalate ", " (folStateName : folSquares ++ moves) ++ "\n"
+                where
+                    iniStateName = mergeMultipleTapeStates $ map (\((ini, _), (_, _, _)) -> ini) cmds
+                    folStateName = mergeMultipleTapeStates $ map (\((_, _), (fol, _, _)) -> fol) cmds
+                    iniSquares = map (\((_, iniSq), (_, _, _)) -> return iniSq) cmds
+                    folSquares = map (\((_, _), (_, folSq, _)) -> return folSq) cmds
+                    moves = map (\((_, _), (_, _, mv)) -> show mv) cmds
+
+-- Section of helper functions.
+
+-- |Process string so that it does not contain illegal characters.
+filterStateName :: String -> String
+filterStateName = replace "^" "v" . filter (\c -> isAlphaNum c || elem c ['_', '^'])
+
+-- |Concat and filter list of states.
+mergeMultipleTapeStates :: [State] -> String
+mergeMultipleTapeStates = ("Q__" ++ ) . intercalate "__" . map filterStateName . enum
+    where
+        enum ss = fmap (\(num, (State s)) -> show num ++ "__" ++ s) (zip [0 ..] ss)

--- a/src/TmsType.hs
+++ b/src/TmsType.hs
@@ -17,9 +17,11 @@ import TMType
 --
 -- 'ChangeTo t' is change it from anything to 't'.
 data TmsTapeSquare = Leave | ChangeFromTo Char Char | ChangeTo Char
+    deriving (Eq)
 
 -- |Type of Tms tape head movement
 data TmsTapeHeadMovement = MoveLeft | Stay | MoveRight
+    deriving (Eq)
 
 instance Show TmsTapeHeadMovement where
     show MoveLeft  = "<"
@@ -29,13 +31,16 @@ instance Show TmsTapeHeadMovement where
 -- |Type of Tms command for one tape.
 -- TmsSingleTapeCommand (action, prevState, nextState, movement).
 newtype TmsSingleTapeCommand = TmsSingleTapeCommand (TmsTapeSquare, State, State, TmsTapeHeadMovement)
+    deriving (Eq)
 
 -- |Type of Tms command for entire Turing machine.
 newtype TmsCommand = TmsCommand [TmsSingleTapeCommand]
+    deriving (Eq)
 
 -- |Type of Tms format.
--- Tms (name, initState, acceptStates, commands, tapeAlphabets).
+-- Tms            (name,   init     accept     commands,     tapeAlphabets).
 newtype Tms = Tms (String, [State], [[State]], [TmsCommand], [[Char]])
+    deriving (Eq)
 
 instance Show Tms where
     show

--- a/src/TuringMachineReader.hs
+++ b/src/TuringMachineReader.hs
@@ -1,0 +1,16 @@
+module TuringMachineReader (parser) where
+
+import Text.Megaparsec
+
+import Data.Text (Text)
+import Data.String
+
+import TMType
+import ParsingHelpers
+
+-- |Parser part.
+
+pTuringMachine :: Parser TM
+pTuringMachine = undefined
+
+parser = makeEofParser pTuringMachine

--- a/src/TuringMachineWriter.hs
+++ b/src/TuringMachineWriter.hs
@@ -1,76 +1,13 @@
--- |This module provides functionality for presenting the Turing machine 'TM' in a text format appropriate to this service: https://turingmachinesimulator.com/
--- Below this format will be called Tms.
+-- |This module provides functionality for converting the Turing machine 'TM' to 'Tms' from module 'TmsType'.
 module TuringMachineWriter (tm2tms) where
 
-import GHC.Unicode (isAlphaNum)
-import Data.List.Utils (replace)
-import Data.List (intercalate, transpose)
+import Data.List (transpose)
 import Data.Set (toList)
 import Data.Map (fromList, lookup, Map)
 import Data.List.NonEmpty (reverse, NonEmpty(..), length)
 
 import TMType
-
--- |Type of Tms tape square action.
---
--- 'Leave' is leave any character unchanged.
---
--- 'ChangeFromTo f t' is change it from 'f' to 't'.
---
--- 'ChangeTo t' is change it from anything to 't'.
-data TmsTapeSquare = Leave | ChangeFromTo Char Char | ChangeTo Char
-
--- |Type of Tms tape head movement
-data TmsTapeHeadMovement = MoveLeft | Stay | MoveRight
-
-instance Show TmsTapeHeadMovement where
-    show MoveLeft  = "<"
-    show Stay      = "-"
-    show MoveRight = ">"
-
--- |Type of Tms command for one tape.
--- TmsSingleTapeCommand (action, prevState, nextState, movement).
-newtype TmsSingleTapeCommand = TmsSingleTapeCommand (TmsTapeSquare, State, State, TmsTapeHeadMovement)
-
--- |Type of Tms command for entire Turing machine.
-newtype TmsCommand = TmsCommand [TmsSingleTapeCommand]
-
--- |Type of Tms format.
--- Tms (name, initState, acceptStates, commands, tapeAlphabets).
-newtype Tms = Tms (String, [State], [[State]], [TmsCommand], [[Char]])
-
-instance Show Tms where
-    show
-        (Tms
-            (name,
-            initial,
-            acStates,
-            commands,
-            tapeAlphabets)
-        ) = "name: " ++ name ++ "\n" ++
-        "init: " ++ mergeMultipleTapeStates initial ++ "\n" ++
-        "accept: " ++ intercalate ", " (map mergeMultipleTapeStates acStates) ++ "\n\n" ++
-        intercalate "\n\n" (map showTmsCommand commands)
-        where
-            showTmsCommand :: TmsCommand -> String
-            showTmsCommand (TmsCommand tapeCommands) = intercalate "\n" $ map showSingleCmd $ combine $ map extCommand (zip tapeAlphabets tapeCommands)
-            extCommand :: ([Char], TmsSingleTapeCommand) -> [((State, Char), (State, Char, TmsTapeHeadMovement))]
-            extCommand (alph, (TmsSingleTapeCommand (Leave, iniSt, folSt, mv))) =
-                [((iniSt, ch), (folSt, ch, mv)) | ch <- '_' : alph]
-            extCommand (_,    (TmsSingleTapeCommand (ChangeFromTo cF cT, iniSt, folSt, mv))) =
-                [((iniSt, cF), (folSt, cT, mv))]
-            extCommand (alph, (TmsSingleTapeCommand (ChangeTo cT, iniSt, folSt, mv))) =
-                [((iniSt, cF), (folSt, cT, mv)) | cF <- '_' : alph]
-            combine = map Prelude.reverse . foldl (\combs cur -> flip (:) <$> combs <*> cur) [[]]
-            showSingleCmd :: [((State, Char), (State, Char, TmsTapeHeadMovement))] -> String
-            showSingleCmd cmds = intercalate ", " (iniStateName : iniSquares) ++ "\n" ++
-                                 intercalate ", " (folStateName : folSquares ++ moves) ++ "\n"
-                where
-                    iniStateName = mergeMultipleTapeStates $ map (\((ini, _), (_, _, _)) -> ini) cmds
-                    folStateName = mergeMultipleTapeStates $ map (\((_, _), (fol, _, _)) -> fol) cmds
-                    iniSquares = map (\((_, iniSq), (_, _, _)) -> return iniSq) cmds
-                    folSquares = map (\((_, _), (_, folSq, _)) -> return folSq) cmds
-                    moves = map (\((_, _), (_, _, mv)) -> show mv) cmds
+import TmsType
 
 tm2tms :: TM -> Either String Tms
 tm2tms
@@ -91,16 +28,6 @@ tm2tms
         alph2tmsAlph (TapeAlphabet squares) = traverse toValue (toList squares)
  
 -- Section of helper functions.
-
--- |Process string so that it does not contain illegal characters.
-filterStateName :: String -> String
-filterStateName = replace "^" "v" . filter (\c -> isAlphaNum c || elem c ['_', '^'])
-
--- |Concat and filter list of states.
-mergeMultipleTapeStates :: [State] -> String
-mergeMultipleTapeStates = ("Q__" ++ ) . intercalate "__" . map filterStateName . enum
-    where
-        enum ss = fmap (\(num, (State s)) -> show num ++ "__" ++ s) (zip [0 ..] ss)
 
 -- |Make transitional state.
 -- Being used in 'cmd2tmsTapeCmd' if more than one command is created.

--- a/src/TuringMachineWriter.hs
+++ b/src/TuringMachineWriter.hs
@@ -1,6 +1,39 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+-- |This module provides functionality for presenting the Turing machine 'TM' in a text format appropriate to this service: https://turingmachinesimulator.com/
 module TuringMachineWriter (toTMSimulator) where
+
+import GHC.Unicode (isAlphaNum)
+import Data.List.Utils (replace)
+import Data.List (intercalate)
 
 import TMType
 
-toTMSimulator :: TM -> String
-toTMSimulator m = "TM placeholder"
+class ShowTMSimulator a where
+    toTMSimulator :: a -> String
+
+filterStateName :: String -> String
+filterStateName = replace "^" "v" . filter (\c -> isAlphaNum c || elem c ['_', '^'])
+
+mergeMultipleTapeStates :: [State] -> String
+mergeMultipleTapeStates = ("Q__" ++ ) . intercalate "__" . map filterStateName . enum
+    where
+        enum ss = fmap (\(num, (State s)) -> show num ++ "__" ++ s) (zip [0 ..] ss)
+
+instance ShowTMSimulator [TapeCommand] where
+    toTMSimulator cmds = "command placeholder"
+
+instance ShowTMSimulator TM where
+    toTMSimulator
+        (TM
+            (inputAlphabet,
+            tapeAlphabets, 
+            MultiTapeStates multiTapeStates, 
+            Commands commands, 
+            StartStates startStates, 
+            AccessStates accessStates)
+        ) =
+        "name: TM\n" ++
+        "init: " ++ mergeMultipleTapeStates startStates ++ "\n" ++
+        "accept: " ++ mergeMultipleTapeStates accessStates ++ "\n\n" ++
+        concatMap ((++ "\n\n") . toTMSimulator) commands

--- a/src/TuringMachineWriter.hs
+++ b/src/TuringMachineWriter.hs
@@ -1,21 +1,16 @@
 -- |This module provides functionality for presenting the Turing machine 'TM' in a text format appropriate to this service: https://turingmachinesimulator.com/
 -- Below this format will be called Tms.
-module TuringMachineWriter (showAsTms) where
+module TuringMachineWriter (tm2tms) where
 
 import GHC.Unicode (isAlphaNum)
 import Data.List.Utils (replace)
-import Data.List (intercalate)
+import Data.List (intercalate, transpose)
+import Data.Set (toList, fromList, Set)
+import Data.Map (fromList, lookup, Map)
+import Data.Char (ord, chr, toTitle)
+import Data.List.NonEmpty (reverse, NonEmpty(..), length)
 
 import TMType
-
-showAsTms :: TM -> String
-showAsTms m = show $ Tms
-    ("MyTM", [State "q01", State "q02"], [[State "q22", State "q15"]], [
-            TmsCommand
-                [
-                    TmsSingleTapeCommand (Leave,                State "q0", State "q1", Stay),
-                    TmsSingleTapeCommand (ChangeFromTo '0' '1', State "q2", State "q4", MoveLeft)
-                ]], ["01", "01"])
 
 -- |Type of Tms tape square action.
 --
@@ -67,7 +62,7 @@ instance Show Tms where
                 [((iniSt, cF), (folSt, cT, mv))]
             extCommand (alph, (TmsSingleTapeCommand (ChangeTo cT, iniSt, folSt, mv))) =
                 [((iniSt, cF), (folSt, cT, mv)) | cF <- '_' : alph]
-            combine = map reverse . foldl (\combs cur -> flip (:) <$> combs <*> cur) [[]]
+            combine = map Prelude.reverse . foldl (\combs cur -> flip (:) <$> combs <*> cur) [[]]
             showSingleCmd :: [((State, Char), (State, Char, TmsTapeHeadMovement))] -> String
             showSingleCmd cmds = intercalate ", " (iniStateName : iniSquares) ++ "\n" ++
                                  intercalate ", " (folStateName : folSquares ++ moves) ++ "\n"
@@ -78,6 +73,24 @@ instance Show Tms where
                     folSquares = map (\((_, _), (_, folSq, _)) -> return folSq) cmds
                     moves = map (\((_, _), (_, _, mv)) -> show mv) cmds
 
+tm2tms :: TM -> Either String Tms
+tm2tms
+    (TM
+        (inputAlphabet,
+        tapeAlphabets, 
+        MultiTapeStates multiTapeStates, 
+        Commands commands, 
+        StartStates startStates, 
+        AccessStates accessStates)
+    ) = do
+        tmsCmdsBlocks <- traverse cmd2tmsTapeCmds (toList commands)
+        let tmsCmds = filter (not . noChangeCommand) $ concat tmsCmdsBlocks
+        tmsAlph <- traverse alph2tmsAlph tapeAlphabets
+        return $ Tms ("TuringMachine", startStates, [accessStates], tmsCmds, tmsAlph)
+    where
+        alph2tmsAlph :: TapeAlphabet -> Either String [Char]
+        alph2tmsAlph (TapeAlphabet squares) = traverse toValue (toList squares)
+ 
 -- Section of helper functions.
 
 -- |Process string so that it does not contain illegal characters.
@@ -89,3 +102,110 @@ mergeMultipleTapeStates :: [State] -> String
 mergeMultipleTapeStates = ("Q__" ++ ) . intercalate "__" . map filterStateName . enum
     where
         enum ss = fmap (\(num, (State s)) -> show num ++ "__" ++ s) (zip [0 ..] ss)
+
+makeTransSt :: State -> State -> State
+makeTransSt (State from) (State to) = State $ "FROM_" ++ from ++ "_TO_" ++ to
+
+-- |Convert 'TapeCommand' to non empty list of 'TmsSingleTapeCommand'.
+cmd2tmsTapeCmd :: TapeCommand -> Either String (NonEmpty TmsSingleTapeCommand)
+
+-- Command translation cases.
+
+-- 'TM' : Do not change anything.
+-- 'Tms': Do not change anything.
+cmd2tmsTapeCmd (
+    SingleTapeCommand (
+        (ES, iniSt, RBS),
+        (ES, folSt, RBS))
+    ) = return $
+    (TmsSingleTapeCommand (Leave, iniSt, folSt, Stay)) :|
+    []
+
+-- 'TM' : Insert value to the left from head.
+-- 'Tms': Move head to left and put the value there.
+cmd2tmsTapeCmd (
+    SingleTapeCommand (
+        (ES,                 iniSt, RBS),
+        ((Value name nquts), folSt, RBS)
+    )) = return $
+    (TmsSingleTapeCommand  (Leave,                                    iniSt,                     (makeTransSt iniSt folSt), MoveLeft)) :|
+    [(TmsSingleTapeCommand (ChangeFromTo '_' $ name'n'quotes2Char name nquts, (makeTransSt iniSt folSt), folSt,                     Stay))]
+
+-- 'TM' : Erase symbol to the left from the head.
+-- 'Tms': Erase (put empty symbol) value in head position and move head to right.
+cmd2tmsTapeCmd (
+    SingleTapeCommand (
+        ((Value name nquts), iniSt, RBS),
+        (ES,                 folSt, RBS)
+    )) = return $
+    (TmsSingleTapeCommand (ChangeFromTo (name'n'quotes2Char name nquts) '_', iniSt, folSt, MoveRight)) :|
+    []
+
+-- 'TM' : Replace value to left from the head.
+-- 'Tms': Change value in head position.
+cmd2tmsTapeCmd (
+    SingleTapeCommand (
+        ((Value iniName iniNquts), iniSt, RBS),
+        ((Value folName folNquts), folSt, RBS)
+    )) = return $
+    (TmsSingleTapeCommand
+        (ChangeFromTo (name'n'quotes2Char iniName iniNquts) (name'n'quotes2Char folName folNquts),
+        iniSt,
+        folSt,
+        Stay)) :|
+    []
+
+-- 'TM' : Check if tape is empty.
+-- 'Tms': Check if tape is empty.
+cmd2tmsTapeCmd (
+    SingleTapeCommand (
+        (LBS, iniSt, RBS),
+        (LBS, folSt, RBS)
+    )) = return $
+    (TmsSingleTapeCommand (ChangeFromTo '_' '_', iniSt, folSt, Stay)) :|
+    []
+
+-- Command can not be translated to Tms format.
+cmd2tmsTapeCmd cmd = fail $ "Command '" ++ show cmd ++ "' can not be converted to '[TmsSingleTapeCommand]'"
+
+cmd2tmsTapeCmds :: [TapeCommand] -> Either String [TmsCommand]
+cmd2tmsTapeCmds cmds = do
+    tapeCmdSeqs <- traverse cmd2tmsTapeCmd cmds -- :: [NonEmpty TmsSingleTapeCommand]
+    let tapeCmdSeqsRev = Prelude.map Data.List.NonEmpty.reverse tapeCmdSeqs
+    let mxLen = foldl (\mx sq -> max mx (Data.List.NonEmpty.length sq)) 0 tapeCmdSeqs
+    let sameLenCmds = fmap (fillSeqWithIdCmds mxLen) tapeCmdSeqsRev
+    let sameLenCmdsRev = fmap Prelude.reverse sameLenCmds
+    return $ TmsCommand <$> transpose sameLenCmdsRev
+    where
+        fillSeqWithIdCmds :: Int -> NonEmpty TmsSingleTapeCommand -> [TmsSingleTapeCommand]
+        fillSeqWithIdCmds len (x :| xs) = replicate (len - (Prelude.length xs) - 1) (makeIdTapeCommand x) ++ pure x ++ xs
+        makeIdTapeCommand :: TmsSingleTapeCommand -> TmsSingleTapeCommand
+        makeIdTapeCommand (TmsSingleTapeCommand (_, _, st, mv)) = TmsSingleTapeCommand (Leave, st, st, Stay)
+
+-- |Convert 'Square' to 'Char'.
+toValue :: Square -> Either String Char
+toValue (Value name n) = pure $ name'n'quotes2Char name n
+toValue _              = fail "Square is expected to be 'Value' to convert to 'Char'"
+
+-- Character length is exactly 1, so longer strings can not be supported, so as many quotes.
+name'n'quotes2Char :: String -> Int -> Char
+name'n'quotes2Char (c : "") 0 = c
+name'n'quotes2Char (c : "") 1 = toQuot c
+name'n'quotes2Char name nQuot = error $ "Can not convert name '" ++ name ++ "' with " ++ show nQuot ++ "quotes into 'Char'."
+
+quoted :: Data.Map.Map Char Char
+quoted = Data.Map.fromList [('a', 'à'), ('b', 'ƀ'), ('c', 'ć'), ('d', 'ď'), ('e', 'ė'), ('f', 'ƒ'), ('g', 'ĝ'), ('h', 'ĥ'), ('i', 'ĩ'), ('j', 'ĵ'), ('k', 'ķ'), ('l', 'ĺ'), ('m', 'ɱ'), ('n', 'ń'), ('o', 'ō'), ('p', 'ƥ'), ('q', 'ɋ'), ('r', 'ŕ'), ('s', 'ś'), ('t', 'ť'), ('u', 'ū'), ('v', 'ʌ'), ('w', 'ŵ'), ('x', '×'), ('y', 'ŷ'), ('z', 'ź'), ('A', 'Ã'), ('B', 'Ɓ'), ('C', 'Ć'), ('D', 'Đ'), ('E', 'Ė'), ('F', 'Ƒ'), ('G', 'Ĝ'), ('H', 'Ĥ'), ('I', 'Ĩ'), ('J', 'Ĵ'), ('K', 'Ķ'), ('L', 'Ĺ'), ('M', 'Ɯ'), ('N', 'Ń'), ('O', 'Ō'), ('P', 'Ƥ'), ('Q', 'Ɋ'), ('R', 'Ŕ'), ('S', 'Ś'), ('T', 'Ť'), ('U', 'Ū'), ('V', 'Ʌ'), ('W', 'Ŵ'), ('X', 'χ'), ('Y', 'Ŷ'), ('Z', 'Ź')]
+
+toQuot :: Char -> Char
+toQuot c = case Data.Map.lookup c quoted of
+    Nothing -> error $ "Can not find character with quote for '" ++ pure c ++ "'"
+    Just c' -> c'
+
+-- |Check if command changes nothing, so it can be paifully removed.
+noChangeCommand :: TmsCommand -> Bool
+noChangeCommand (TmsCommand cmds) = all noChangeTapeCommand cmds
+    where
+        noChangeTapeCommand :: TmsSingleTapeCommand -> Bool
+        noChangeTapeCommand (TmsSingleTapeCommand (Leave,            ini, fol, Stay)) | ini == fol           = True
+        noChangeTapeCommand (TmsSingleTapeCommand (ChangeFromTo f t, ini, fol, Stay)) | ini == fol && f == t = True
+        noChangeTapeCommand _                                                                                = False

--- a/src/TuringMachineWriter.hs
+++ b/src/TuringMachineWriter.hs
@@ -1,0 +1,6 @@
+module TuringMachineWriter (toTMSimulator) where
+
+import TMType
+
+toTMSimulator :: TM -> String
+toTMSimulator m = "TM placeholder"

--- a/src/TuringMachineWriter.hs
+++ b/src/TuringMachineWriter.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE FlexibleInstances #-}
-
 -- |This module provides functionality for presenting the Turing machine 'TM' in a text format appropriate to this service: https://turingmachinesimulator.com/
-module TuringMachineWriter (toTMSimulator) where
+-- Below this format will be called Tms.
+module TuringMachineWriter (showAsTms) where
 
 import GHC.Unicode (isAlphaNum)
 import Data.List.Utils (replace)
@@ -9,8 +8,76 @@ import Data.List (intercalate)
 
 import TMType
 
-class ShowTMSimulator a where
-    toTMSimulator :: a -> String
+showAsTms :: TM -> String
+showAsTms m = show $ Tms
+    ("MyTM", [State "q01", State "q02"], [[State "q22", State "q15"]], [
+            TmsCommand
+                [
+                    TmsSingleTapeCommand ((State "q0", Any), (State "q1", Label '0', MoveLeft)),
+                    TmsSingleTapeCommand ((State "q0", Any), (State "q1", Label '0', MoveLeft))
+                ]], ["01", "01"])
+
+-- |Type of Tms tape cell.
+--
+-- 'Any' is any type of cell.
+--
+-- 'Label' is labeled type of cell.
+data TmsTapeSquare = Any | Label Char
+
+tmssq2chars :: [Char] -> TmsTapeSquare -> [Char]
+tmssq2chars alphabet Any       = alphabet
+tmssq2chars alphabet (Label c) = pure c
+
+-- |Type of Tms tape head movement
+data TmsTapeHeadMovement = MoveLeft | Stay | MoveRight
+
+instance Show TmsTapeHeadMovement where
+    show MoveLeft  = "<"
+    show Stay      = "-"
+    show MoveRight = ">"
+
+-- |Type of Tms command for one tape.
+newtype TmsSingleTapeCommand = TmsSingleTapeCommand ((State, TmsTapeSquare), (State, TmsTapeSquare, TmsTapeHeadMovement))
+
+-- |Type of Tms command for entire Turing machine.
+newtype TmsCommand = TmsCommand [TmsSingleTapeCommand]
+
+-- |Type of Tms format.
+-- Tms (name, initState, acceptStates, commands, tapeAlphabets).
+newtype Tms = Tms (String, [State], [[State]], [TmsCommand], [[Char]])
+
+instance Show Tms where
+    show
+        (Tms
+            (name,
+            init,
+            acStates,
+            commands,
+            tapeAlphabets)
+        ) = "name: " ++ name ++ "\n" ++
+        "init: " ++ mergeMultipleTapeStates init ++ "\n" ++
+        "accept: " ++ intercalate ", " (map mergeMultipleTapeStates acStates) ++ "\n\n" ++
+        intercalate "\n\n" (map showTmsCommand commands)
+        where
+            showTmsCommand :: TmsCommand -> String
+            showTmsCommand (TmsCommand tapeCommands) = intercalate "\n" $ map showSingleCmd $ combine $ map extCommand (zip tapeAlphabets tapeCommands)
+            extCommand :: ([Char], TmsSingleTapeCommand) -> [((State, Char), (State, Char, TmsTapeHeadMovement))]
+            extCommand (alph, (TmsSingleTapeCommand ((iniSt, iniSq), (folSt, folSq, mv)))) =
+                [((iniSt, iniChar), (folSt, folChar, mv)) | iniChar <- tmssq2chars alph iniSq,
+                                                            folChar <- tmssq2chars alph folSq]
+            combine :: Foldable t => t [a] -> [[a]]
+            combine = foldl (\combs cur -> flip (:) <$> combs <*> cur) [[]]
+            showSingleCmd :: [((State, Char), (State, Char, TmsTapeHeadMovement))] -> String
+            showSingleCmd cmds = intercalate ", " (iniStateName : iniSquares) ++ "\n" ++
+                                 intercalate ", " (folStateName : folSquares ++ moves) ++ "\n"
+                where
+                    iniStateName = mergeMultipleTapeStates $ map (\((ini, _), (_, _, _)) -> ini) cmds
+                    folStateName = mergeMultipleTapeStates $ map (\((_, _), (fol, _, _)) -> fol) cmds
+                    iniSquares = map (\((_, iniSq), (_, _, _)) -> return iniSq) cmds
+                    folSquares = map (\((_, _), (_, folSq, _)) -> return folSq) cmds
+                    moves = map (\((_, _), (_, _, mv)) -> show mv) cmds
+
+-- Section of helper functions.
 
 filterStateName :: String -> String
 filterStateName = replace "^" "v" . filter (\c -> isAlphaNum c || elem c ['_', '^'])
@@ -19,21 +86,3 @@ mergeMultipleTapeStates :: [State] -> String
 mergeMultipleTapeStates = ("Q__" ++ ) . intercalate "__" . map filterStateName . enum
     where
         enum ss = fmap (\(num, (State s)) -> show num ++ "__" ++ s) (zip [0 ..] ss)
-
-instance ShowTMSimulator [TapeCommand] where
-    toTMSimulator cmds = "command placeholder"
-
-instance ShowTMSimulator TM where
-    toTMSimulator
-        (TM
-            (inputAlphabet,
-            tapeAlphabets, 
-            MultiTapeStates multiTapeStates, 
-            Commands commands, 
-            StartStates startStates, 
-            AccessStates accessStates)
-        ) =
-        "name: TM\n" ++
-        "init: " ++ mergeMultipleTapeStates startStates ++ "\n" ++
-        "accept: " ++ mergeMultipleTapeStates accessStates ++ "\n\n" ++
-        concatMap ((++ "\n\n") . toTMSimulator) commands

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import ConfigType
 import SMTests
 import GrTests
 import ParserTests
+import TuringMachineWriterTests
 
 test1Grammar :: Grammar
 test1Grammar = grammar where
@@ -78,5 +79,9 @@ main = defaultMainWithOpts
         testCase "sm2gr test" sm2grTest,
         testCase "custom CFG to TM" testCustomCFG,
         testCase "custom conjunctive to TM" testCustomConjunctive,
-        testCase "custom boolean to TM" testCustomBoolean]
+        testCase "custom boolean to TM" testCustomBoolean,
+        testCase "show one tape Tms" testShowOneTapeTms,
+        testCase "show multi tape Tms" testShowMultiTapeTms,
+        testCase "one tape TM to Tms" testOneTapeTM2Tms,
+        testCase "multi tape TM to Tms" testMultiTapeTM2Tms]
        mempty

--- a/test/TuringMachineWriterTests.hs
+++ b/test/TuringMachineWriterTests.hs
@@ -1,0 +1,164 @@
+module TuringMachineWriterTests (testShowOneTapeTms, testShowMultiTapeTms, testOneTapeTM2Tms, testMultiTapeTM2Tms) where
+
+import Test.HUnit
+import Data.Set (fromList)
+
+import TmsType
+import TMType
+import TuringMachineWriter
+
+oneTapeTM :: TM
+oneTapeTM = TM (
+    InputAlphabet (fromList [
+        a, b
+    ]),
+    [
+        TapeAlphabet (
+            fromList [
+                a, b
+            ]
+        )
+    ],
+    MultiTapeStates [
+        fromList [
+            q11
+        ]
+    ],
+    Commands (
+        fromList [
+            [SingleTapeCommand ((a,   q11, RBS), (ES,  q11, RBS))]
+        ]
+    ),
+    StartStates [q11],
+    AccessStates [q22]
+    )
+
+multiTapeTM :: TM
+multiTapeTM = TM (
+    InputAlphabet (fromList [
+        a, b
+    ]),
+    [
+        TapeAlphabet (
+            fromList [
+                a
+            ]
+        ),
+        TapeAlphabet (
+            fromList [
+                a'
+            ]
+        ),
+        TapeAlphabet (
+            fromList [
+                a'
+            ]
+        )
+    ],
+    MultiTapeStates [
+        fromList [
+            q11
+        ],
+        fromList [
+            q22
+        ],
+        fromList [
+            q33
+        ]
+    ],
+    Commands (
+        fromList [
+            [
+                SingleTapeCommand ((a,  q11, RBS), (a,   q11, RBS)),
+                SingleTapeCommand ((a', q22, RBS), (ES,  q22, RBS)),
+                SingleTapeCommand ((a', q33, RBS), (a',  q33, RBS))
+            ]
+        ]
+    ),
+    StartStates [q11, q22, q33],
+    AccessStates [q11, q22, q33]
+    )
+
+testShowOneTapeTms :: Assertion
+testShowOneTapeTms = testShowTms oneTapeTms "\
+    \name: TuringMachine\n\
+    \init: Q__0__q_1v1\n\
+    \accept: Q__0__q_2v2\n\n\
+    \Q__0__q_1v1, a\n\
+    \Q__0__q_1v1, _, >\n"
+
+testShowMultiTapeTms :: Assertion
+testShowMultiTapeTms = testShowTms multiTapeTms "\
+    \name: TuringMachine\n\
+    \init: Q__0__q_1v1__1__q_2v2__2__q_3v3\n\
+    \accept: Q__0__q_1v1__1__q_2v2__2__q_3v3\n\n\
+    \Q__0__q_1v1__1__q_2v2__2__q_3v3, a, à, à\n\
+    \Q__0__q_1v1__1__q_2v2__2__q_3v3, a, _, à, -, >, -\n"
+
+testOneTapeTM2Tms :: Assertion
+testOneTapeTM2Tms = testTM2Tms oneTapeTM oneTapeTms
+
+testMultiTapeTM2Tms :: Assertion
+testMultiTapeTM2Tms = testTM2Tms multiTapeTM multiTapeTms
+
+q11 :: TMType.State
+q11 = TMType.State "q_{1}^{1}"
+
+q22 :: TMType.State
+q22 = TMType.State "q_{2}^{2}"
+
+q33 :: TMType.State
+q33 = TMType.State "q_{3}^{3}"
+
+a :: Square
+a = Value "a" 0
+
+b :: Square
+b = Value "b" 0
+
+a' :: Square
+a' = Value "a" 1
+
+oneTapeTms :: Tms
+oneTapeTms = Tms (
+        "TuringMachine",
+        [q11],
+        [[q22]],
+        [
+            TmsCommand [
+                TmsSingleTapeCommand (ChangeFromTo 'a' '_', q11, q11, MoveRight)
+            ]
+        ],
+        [
+            ['a', 'b']
+        ]
+    )
+
+multiTapeTms :: Tms
+multiTapeTms = Tms (
+        "TuringMachine",
+        [q11, q22, q33],
+        [[q11, q22, q33]],
+        [
+            TmsCommand [
+                TmsSingleTapeCommand (ChangeFromTo 'a' 'a', q11, q11, Stay),
+                TmsSingleTapeCommand (ChangeFromTo 'à' '_', q22, q22, MoveRight),
+                TmsSingleTapeCommand (ChangeFromTo 'à' 'à', q33, q33, Stay)
+            ]
+        ],
+        [
+            ['a'],
+            ['à'],
+            ['à']
+        ]
+    )
+
+testShowTms :: Tms -> String -> Assertion
+testShowTms tms res = assertEqual ("Invalid presentation of Tms.") res' res
+    where
+        res' = show tms
+
+testTM2Tms :: TM -> Tms -> Assertion
+testTM2Tms tm tms = case tm2tms tm of
+    Left err -> assertFailure $ "Conversion from TM to Tms has failed: " ++ err
+    Right tm' -> assertEqual ("TM is not correctly converted to Tms.") tm' tms


### PR DESCRIPTION
- Создан тип `Tms`, который отвечает формату машин Тьюринга на [turingmachinesimulator](https://turingmachinesimulator.com/) и `Show` для его соответственно.
- Реализовано преобразование `TM` -> `Tms`. Пока для наглядности эту фукнцию я вставил в функцию `convertGrammar2TM`, где нужно выводить выводить машину Тьюринга на экран.
- Добавлены тесты для вышеперечисленных функций.

Я пробовал вводить простые грамматики, вывод вставлял в [turingmachinesimulator](https://turingmachinesimulator.com/) и он, кажется, принимал нужные слова.